### PR TITLE
Fix webpack devtool config

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "body-parser": "^1.17.2",
+    "css-loader": "^0.28.4",
     "ejs": "^2.5.6",
     "express": "^4.15.2",
     "express-ejs-layouts": "^2.3.0",
@@ -21,6 +22,7 @@
     "react-dom": "^15.5.4",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
+    "style-loader": "^0.18.2",
     "webpack": "^2.5.1"
   },
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 module.exports = {
   context: path.join(__dirname, 'src'),
-  devtool: debug ? 'inline-sourcemap' : null,
+  devtool: debug ? 'inline-sourcemap' : false,
   entry: './js/App.js',
   module: {
     loaders: [


### PR DESCRIPTION
The devtool should be a string or false: 
```
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.devtool should be one of these:
   string | false
   A developer tool to enhance debugging.
   Details:
    * configuration.devtool should be a string.
    * configuration.devtool should be false
```